### PR TITLE
(fix) TextStyle can not patchProps after modified

### DIFF
--- a/packages/vue3-pixi/src/renderer/internal/default-renderer.ts
+++ b/packages/vue3-pixi/src/renderer/internal/default-renderer.ts
@@ -79,7 +79,7 @@ const TextRender: RendererOptions = {
         setSkipFirstValue(el, key, () => el.text = next)
         break
       case 'style':
-        setSkipFirstValue(el, key, () => setObjectProperty(el.style, key, prev, next))
+        setSkipFirstValue(el, key, () => setObjectProperty(el, key, prev, next))
         break
       default:
         defuPatchProp(el, key, prev, next)


### PR DESCRIPTION
Hi!! thx for nice library
but i got problem with the `TextStyle`

```typescript
      case 'style':
        setSkipFirstValue(el, key, () => setObjectProperty(el.style, key, prev, next))
```
`setObjectProperty(el.style, key, prev, next)` will be equivant to about `TextStyle['style'] = next` is not correctly, it want to replace `style` prop of the `el`