### PR TITLE
fix: animated sprite prop types

### DIFF
--- a/docs/guide/elements/animated-sprite.md
+++ b/docs/guide/elements/animated-sprite.md
@@ -24,7 +24,7 @@ I recommend using spritesheets created by TexturePacker ([they have a great tuto
 | anchor | <api-point /> | `0` | The anchor sets the origin point of the text. |
 | anchor-x | ^[number] | `0` | The x anchor sets the origin point of the text. |
 | anchor-y | ^[number] | `0` | The y anchor sets the origin point of the text. |
-| textures | ^[array]`Array<Texture \| string>` | `undefined` | The textures to use for the animation |
+| textures | ^[array]`Array<Texture \| FrameObject \| string>` | `undefined` | The textures to use for the animation |
 | animation-speed | ^[number] | `1` | The speed that the AnimatedSprite will play at. Higher is faster, lower is slower |
 | loop | ^[boolean] | `true` | Whether or not the animate sprite repeats after playing. |
 | playing | ^[boolean] | `false` | Whether or not the animation is playing. |

--- a/packages/vue3-pixi/src/elements/animatedSprite.ts
+++ b/packages/vue3-pixi/src/elements/animatedSprite.ts
@@ -6,8 +6,9 @@ import type {
 import type * as PIXI from 'pixi.js'
 import type { AllowedPixiProps } from './props'
 import type { PixiEvents } from './events'
+
 export interface AnimatedSpriteProps extends AllowedPixiProps {
-  textures: (PIXI.Texture | string)[]
+  textures: (PIXI.Texture | PIXI.FrameObject | string)[]
   width?: number
   height?: number
 


### PR DESCRIPTION
Improved the types for the `<animated-sprite>` component to accept FrameObjects as textures to match Pixi's type definitions. This allows to specify a duration for every frame of the animation.