### PR TITLE
Update quick-start.md

### DIFF
--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -50,7 +50,7 @@ add Vue plugin configuration to support custom elements, prevent parsing excepti
 ```ts
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
-import { isCustomElement, transformAssetUrls } from 'vue3-pixi'
+import { isCustomElement, transformAssetUrls } from 'vue3-pixi/compiler'
 
 export default defineConfig({
   plugins: [


### PR DESCRIPTION
The current version of the docs does not seem to work, as reported in #100 

Importing from the compiler module directly side-steps the accidental import of browser-only parts pixi in the vite build pipeline. 