### PR TITLE
fix(v8): guard against null geometry crash in batch renderer

### DIFF
--- a/packages/core/src/elements/mesh.ts
+++ b/packages/core/src/elements/mesh.ts
@@ -20,7 +20,11 @@ renderer.use({
       case 'geometry':
       case 'shader':
       case 'state':
-        setters.unfirst(el, key, () => el[key] = next)
+        // Guard against null — PIXI v8's Mesh.destroy() nulls _geometry internally,
+        // and the batch renderer crashes if it encounters null geometry during execute.
+        // Only update if next is non-null; null values are handled by v-if removal.
+        if (next != null)
+          setters.unfirst(el, key, () => el[key] = next)
         break
       case 'roundPixels':
         setters.boolean(el, key, prev, next)

--- a/packages/core/src/renderer/internal/options.ts
+++ b/packages/core/src/renderer/internal/options.ts
@@ -58,6 +58,12 @@ export function removeContainer(node: Container) {
   }
 
   try {
+    // PIXI v8 fix: Remove from parent BEFORE destroying. The batch renderer may have
+    // already collected this node for the current frame's render pass. If we destroy
+    // first (which nulls Mesh._geometry), the batch execute phase crashes with
+    // "Cannot read properties of null (reading 'geometry')". Removing from parent first
+    // ensures the node won't be in the next render pass's build phase.
+    node.parent?.removeChild(node)
     node.destroy({ children: true })
   }
   catch {


### PR DESCRIPTION
## Problem

PIXI v8's batch renderer can crash with `Cannot read properties of null (reading 'geometry')` during the mesh destroy/unmount lifecycle:

1. A \`<mesh>\` is unmounted mid-frame.
2. \`removeContainer\` calls \`node.destroy({ children: true })\`, which internally nulls \`Mesh._geometry\`.
3. The batch renderer has already collected this node in the current frame's build phase; its execute phase then dereferences the nulled geometry and crashes.

A related crash shape surfaces when a reactive prop on \`<mesh>\` resolves to \`null\` during teardown — \`patchProp\` assigns \`mesh.geometry = null\`, triggering the same batch-renderer crash on the next draw.

## Fix

Two small changes, both narrowly scoped to the mesh/destroy path:

**\`packages/core/src/elements/mesh.ts\`** — skip \`patchProp\` for \`geometry\`/\`shader\`/\`state\` when \`next == null\`. A null value is always a teardown artifact; the correct pattern is to unmount the mesh via \`v-if\`, which is unaffected by this guard.

**\`packages/core/src/renderer/internal/options.ts\`** — in \`removeContainer\`, call \`node.parent?.removeChild(node)\` before \`node.destroy({ children: true })\`. Removing from parent first guarantees the node is not picked up by the next render pass's build phase, so destroy's internal nulling is safe.

## Repro context

Hit in production on a Vue + vue3-pixi + PIXI v8 app (projection-mapping studio) when shader-layer \`<mesh>\` nodes were destroyed on scene changes. Fix has been running in production via \`@virgilvox/vue3-pixi@1.0.0-beta.10\` since March 2026.

## Scope

- 2 files, 11 lines, no behavior change for the non-null path.
- No API surface change.
- No new tests — existing test suite still green with the guard in place.