### PR TITLE
fix: destroy filter instances when container is removed

### DIFF
--- a/packages/core/__tests__/filters.spec.ts
+++ b/packages/core/__tests__/filters.spec.ts
@@ -1,6 +1,6 @@
 import { AlphaFilter, BlurFilter, Container } from 'pixi.js'
 import { describe, expect, it } from 'vitest'
-import { getFilterParent, insertFilter, removeFilter } from '../src/renderer/internal/options'
+import { getFilterParent, insertFilter, removeContainer, removeFilter } from '../src/renderer/internal/options'
 
 describe('filter WeakMap management', () => {
   it('should insert a filter into parent.filters', () => {
@@ -63,5 +63,43 @@ describe('filter WeakMap management', () => {
   it('should not throw when removing a filter with no tracked parent', () => {
     const filter = new AlphaFilter()
     expect(() => removeFilter(filter)).not.toThrow()
+  })
+
+  it('should destroy filters when container is removed via removeContainer', () => {
+    const parent = new Container()
+    const container = new Container()
+    const filter = new AlphaFilter()
+
+    // Attach filter to the inner container
+    insertFilter(filter, container, null)
+    // Add inner container to parent (required for removeContainer to work)
+    parent.addChild(container)
+
+    expect(getFilterParent(filter)).toBe(container)
+
+    // Should not throw when destroying filters
+    expect(() => removeContainer(container)).not.toThrow()
+
+    // Filter should be removed from parent tracking
+    expect(getFilterParent(filter)).toBeUndefined()
+  })
+
+  it('should destroy filters on descendant containers too', () => {
+    const parent = new Container()
+    const child = new Container()
+    const grandchild = new Container()
+    const filter = new AlphaFilter()
+
+    parent.addChild(child)
+    child.addChild(grandchild)
+    insertFilter(filter, grandchild, null)
+
+    expect(getFilterParent(filter)).toBe(grandchild)
+
+    // Should not throw when destroying filters on descendants
+    expect(() => removeContainer(parent)).not.toThrow()
+
+    // Filter should be removed from parent tracking
+    expect(getFilterParent(filter)).toBeUndefined()
   })
 })

--- a/packages/core/src/renderer/internal/options.ts
+++ b/packages/core/src/renderer/internal/options.ts
@@ -1,7 +1,29 @@
-import type { Container, Filter } from 'pixi.js'
+import type { ContainerChild, Filter } from 'pixi.js'
+import { Container } from 'pixi.js'
 import { Empty } from './custom'
 
 const filterParentMap = new WeakMap<Filter, Container>()
+
+/** Walk a container and all descendants, destroy every filter, and clean up the parent map. */
+function destroyFilters(node: Container) {
+  const stack: Container[] = [node]
+  for (let i = 0; i < stack.length; i++) {
+    const container = stack[i]
+    const filters = container.filters
+    if (filters) {
+      const arr = Array.isArray(filters) ? filters : [filters]
+      for (const filter of arr) {
+        filterParentMap.delete(filter)
+        filter.destroy()
+      }
+    }
+    // Collect descendants for breadth-first walk
+    for (const child of container.children as ContainerChild[]) {
+      if (child instanceof Container && !child.destroyed)
+        stack.push(child)
+    }
+  }
+}
 
 export function getFilterParent(filter: Filter): Container | undefined {
   return filterParentMap.get(filter)
@@ -64,6 +86,13 @@ export function removeContainer(node: Container) {
     // "Cannot read properties of null (reading 'geometry')". Removing from parent first
     // ensures the node won't be in the next render pass's build phase.
     node.parent?.removeChild(node)
+
+    // Destroy filters on this container and all descendants. PIXI's own
+    // Container.destroy({ children: true }) only destroys child containers — it
+    // does NOT call .destroy() on attached filters. Without this, every filter
+    // instance (and its GPU resources) leaks when its parent container is removed.
+    destroyFilters(node)
+
     node.destroy({ children: true })
   }
   catch {


### PR DESCRIPTION
## Description

Fix #173 - Filter instances were never destroyed when their parent container was removed, causing GPU resource leaks.

### Changes

- Added `destroyFilters()` helper in `packages/core/src/renderer/internal/options.ts` that walks the container and all descendants, calling `.destroy()` on every filter and cleaning up the `filterParentMap`.
- Called `destroyFilters()` in `removeContainer()` before `node.destroy({ children: true })`.
- Added tests to verify filter destruction on container removal (direct and descendant containers).

### Verification

- Typecheck: `tsc --noEmit` passed
- Tests: 181/181 passed (9 test files)
