### PR TITLE
fix: make nodeOps.parentNode filter-aware

### DIFF
--- a/packages/core/__tests__/nodeOps.spec.ts
+++ b/packages/core/__tests__/nodeOps.spec.ts
@@ -1,7 +1,7 @@
 import { BitmapText, Container, Filter, Text } from 'pixi.js'
 import { describe, expect, it, vi } from 'vitest'
 import { Empty } from '../src/renderer/internal/custom'
-import { createComment, createElement, createText, insert, nextSibling, remove, setText } from '../src/renderer/nodeOps'
+import { createComment, createElement, createText, insert, nextSibling, parentNode, remove, setText } from '../src/renderer/nodeOps'
 import { patchs } from '../src/renderer/utils/patchs'
 
 // Register elements before testing
@@ -163,6 +163,26 @@ describe('nodeOps', () => {
 
       const sibling = nextSibling(filter1 as any)
       expect(sibling).toBe(filter2)
+    })
+
+    it('parentNode resolves a filter\'s container via filterParentMap, not node.parent', () => {
+      const parent = new Container()
+      const filter = new Filter({})
+      ;(filter as any)._vp_filter = true
+
+      insert(filter as any, parent)
+
+      // Filters aren't Containers and have no `.parent` of their own
+      expect((filter as any).parent).toBeUndefined()
+      expect(parentNode(filter as any)).toBe(parent)
+    })
+
+    it('parentNode still returns node.parent for non-filter nodes', () => {
+      const parent = new Container()
+      const child = new Container()
+      parent.addChild(child)
+
+      expect(parentNode(child)).toBe(parent)
     })
   })
 

--- a/packages/core/src/renderer/nodeOps.ts
+++ b/packages/core/src/renderer/nodeOps.ts
@@ -8,6 +8,7 @@ import {
 import { camelize, markRaw, warn } from 'vue-demi'
 import {
   Empty,
+  getFilterParent,
   insertContainer,
   insertFilter,
   nextSiblingContainer,
@@ -52,6 +53,8 @@ export function createElement(prefix: string, name: string, _?: ElementNamespace
 }
 
 export function parentNode(node: any) {
+  if (Reflect.get(node, '_vp_filter'))
+    return getFilterParent(node)
   return node?.parent
 }
 


### PR DESCRIPTION
## Summary
Fixes #176. `insert`/`remove`/`nextSibling` in `nodeOps.ts` all special-case `_vp_filter` nodes and route them through `filterParentMap` (since `Filter` instances aren't `Container`s and have no `.parent`), but `parentNode` didn't:

```js
export function parentNode(node: any) {
  return node?.parent
}
```

Vue core's `patchBlockChildren` calls `hostParentNode(oldVNode.el)` when a block child's vnode *type* changes (e.g. a `Filter` becoming a Comment placeholder as `v-if` goes false) and needs a container to mount the replacement into. For a Filter, that returned `undefined`, which became the `container` argument to `insertContainer` — hitting its unguarded `parent.addChild(child)` branch and throwing `Cannot read properties of undefined (reading 'addChild')`.

Fix: make `parentNode` check `_vp_filter` and resolve via the already-existing `getFilterParent()` (backed by `filterParentMap`), mirroring the other nodeOps functions.

## Test plan
- [x] Added tests in `packages/core/__tests__/nodeOps.spec.ts` asserting `parentNode(filter)` resolves the tracked container (not `filter.parent`, which is `undefined`), and that non-filter behavior is unchanged.
- [x] Confirmed the new test fails on the pre-fix code (`parentNode` returns `undefined` for a filter) and passes after the fix.
- [x] Full suite: `pnpm test` (183/183 passing), `pnpm typecheck` clean, `eslint` clean.