### PR TITLE
feat: expose Application's unmount destroy() options

### DIFF
--- a/docs/guide/components/application.md
+++ b/docs/guide/components/application.md
@@ -33,6 +33,8 @@ You can obtain the Application instance by binding a ref externally, but it is g
 | preserveDrawingBuffer | ^[boolean] | `undefined` | Whether to preserve the drawing buffer |
 | roundPixels | ^[boolean] | `undefined` | Whether to round pixel values |
 | resizeTo | ^[HTMLElement] ^[Window] | `undefined` | Element to auto-resize the renderer to |
+| rendererDestroyOptions | ^[boolean] ^[object] | `{ removeView: true }` | First argument passed to `PixiApplication#destroy()` on unmount |
+| destroyOptions | ^[boolean] ^[object] | `{ children: true, texture: true, textureSource: true, context: true, style: true }` | Second argument passed to `PixiApplication#destroy()` on unmount — set to `{ texture: false, textureSource: false }` to keep textures shared/cached elsewhere (e.g. via `Assets`) alive after this `<Application>` is destroyed |
 
 > more props in [PixiJS ApplicationOptions](https://pixijs.download/release/docs/app.Application.html)
 

--- a/packages/core/__tests__/application.spec.ts
+++ b/packages/core/__tests__/application.spec.ts
@@ -1,11 +1,25 @@
-import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue-demi'
 import { Application } from '../src/components/application'
+
+const { destroyMock } = vi.hoisted(() => ({ destroyMock: vi.fn() }))
 
 // Mock PixiApplication since jsdom has no WebGL
 vi.mock('pixi.js', async (importOriginal) => {
   const actual = await importOriginal() as any
   class MockPixiApplication {
-    stage = { eventMode: 'passive', hitArea: null, on: vi.fn(), children: [] }
+    stage = {
+      eventMode: 'passive',
+      hitArea: null,
+      on: vi.fn(),
+      children: [] as any[],
+      addChild(child: any) { this.children.push(child) },
+      addChildAt(child: any, index: number) { this.children.splice(index, 0, child) },
+      removeChild(child: any) { this.children = this.children.filter((c: any) => c !== child) },
+      getChildIndex(child: any) { return this.children.indexOf(child) },
+    }
+
     screen = new actual.Rectangle(0, 0, 800, 600)
     canvas = document.createElement('canvas')
     renderer = {
@@ -32,7 +46,9 @@ vi.mock('pixi.js', async (importOriginal) => {
       }
     }
 
-    destroy() {}
+    destroy(...args: any[]) {
+      destroyMock(...args)
+    }
   }
 
   return {
@@ -40,6 +56,20 @@ vi.mock('pixi.js', async (importOriginal) => {
     Application: MockPixiApplication,
   }
 })
+
+// The Application component mounts a nested pixi-renderer Vue app onto
+// pixiApp.stage; that inner renderer isn't under test here and jsdom/mocked
+// stage objects don't support it, so stub it out.
+vi.mock('../src/renderer', () => ({
+  createApp: vi.fn(() => ({
+    config: { globalProperties: {} },
+    _context: {},
+    component: vi.fn(),
+    provide: vi.fn(),
+    mount: vi.fn(),
+    unmount: vi.fn(),
+  })),
+}))
 
 describe('application component', () => {
   describe('background prop', () => {
@@ -83,5 +113,44 @@ describe('application component', () => {
       expect(props.width).toBeDefined()
       expect(props.height).toBeDefined()
     })
+  })
+
+  describe('destroy options', () => {
+    beforeEach(() => {
+      destroyMock.mockClear()
+    })
+
+    it('defaults to the previous hardcoded destroy behavior', async () => {
+      const wrapper = mount(Application)
+      await flushMountAndUnmount(wrapper)
+
+      expect(destroyMock).toHaveBeenCalledWith(
+        { removeView: true },
+        { children: true, texture: true, textureSource: true, context: true, style: true },
+      )
+    })
+
+    it('forwards custom rendererDestroyOptions/destroyOptions to PixiApplication#destroy', async () => {
+      const wrapper = mount(Application, {
+        props: {
+          rendererDestroyOptions: { removeView: false },
+          destroyOptions: { children: true, texture: false },
+        },
+      })
+      await flushMountAndUnmount(wrapper)
+
+      expect(destroyMock).toHaveBeenCalledWith(
+        { removeView: false },
+        { children: true, texture: false },
+      )
+    })
+
+    async function flushMountAndUnmount(wrapper: ReturnType<typeof mount>) {
+      // Application's mount() is async (awaits PixiApplication#init)
+      await new Promise(resolve => setTimeout(resolve))
+      wrapper.unmount()
+      // unmount() defers the actual destroy() call to nextTick
+      await nextTick()
+    }
   })
 })

--- a/packages/core/src/components/application/index.ts
+++ b/packages/core/src/components/application/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable ts/no-redeclare */
-import type { ApplicationOptions, ColorSource, Container, GpuPowerPreference } from 'pixi.js'
+import type { ApplicationOptions, ColorSource, Container, DestroyOptions, GpuPowerPreference, RendererDestroyOptions } from 'pixi.js'
 import type { App, PropType } from 'vue-demi'
 import { Application as PixiApplication } from 'pixi.js'
 import { defineComponent, getCurrentInstance, h, markRaw, nextTick, onMounted, onUnmounted, ref, renderSlot, watch } from 'vue-demi'
@@ -43,7 +43,16 @@ export const Application = defineComponent({
     width: { type: [Number, String], default: undefined },
     height: { type: [Number, String], default: undefined },
     resolution: { type: Number, default: 1 },
-
+    /** First argument to `PixiApplication#destroy()` on unmount, controlling the canvas element. */
+    rendererDestroyOptions: {
+      type: [Boolean, Object] as PropType<RendererDestroyOptions>,
+      default: () => ({ removeView: true }),
+    },
+    /** Second argument to `PixiApplication#destroy()` on unmount, controlling stage/texture cleanup. */
+    destroyOptions: {
+      type: [Boolean, Object] as PropType<DestroyOptions>,
+      default: () => ({ children: true, texture: true, textureSource: true, context: true, style: true }),
+    },
   },
   setup(props, { slots, expose }) {
     const { appContext } = getCurrentInstance()!
@@ -53,10 +62,11 @@ export const Application = defineComponent({
     let app: App<Container> | undefined
 
     async function mount() {
+      const { rendererDestroyOptions: _rendererDestroyOptions, destroyOptions: _destroyOptions, ...appOptions } = props
       const inst = new PixiApplication()
       await inst.init({
         canvas: canvas.value,
-        ...props,
+        ...appOptions,
         width: props.width ? Number(props.width) : undefined,
         height: props.height ? Number(props.height) : undefined,
       })
@@ -86,16 +96,7 @@ export const Application = defineComponent({
           return
 
         try {
-          pixiApp.value.destroy(
-            { removeView: true },
-            {
-              children: true,
-              texture: true,
-              textureSource: true,
-              context: true,
-              style: true,
-            },
-          )
+          pixiApp.value.destroy(props.rendererDestroyOptions, props.destroyOptions)
         }
         finally {
           pixiApp.value = undefined


### PR DESCRIPTION
## Summary
Fixes #177. `<Application>`'s unmount hardcoded:

```js
pixiApp.value.destroy(
  { removeView: true },
  { children: true, texture: true, textureSource: true, context: true, style: true },
)
```

This destroys the GPU texture of every display object still on stage at unmount — including textures shared/cached elsewhere (e.g. via `Assets`) that should stay alive after this `<Application>` goes away, with no way to opt out.

Adds `rendererDestroyOptions` / `destroyOptions` props mirroring PixiJS's own `Application#destroy(rendererDestroyOptions, options)` signature, defaulting to the previous hardcoded values for backwards compatibility. Also documented in `docs/guide/components/application.md`.

## Test plan
- [x] Added tests in `packages/core/__tests__/application.spec.ts` mounting/unmounting `<Application>` and asserting `PixiApplication#destroy()` is called with the default values (backwards-compat) and with custom prop values when supplied.
- [x] Confirmed the "custom options" test fails against the pre-fix hardcoded `destroy()` call and passes after the fix.
- [x] Full suite: `pnpm test` (183/183 passing), `pnpm typecheck` clean, `eslint` clean.