### PR TITLE
docs: use a detached container as the render-texture source

### DIFF
--- a/docs/guide/elements/render-texture.md
+++ b/docs/guide/elements/render-texture.md
@@ -4,46 +4,56 @@ Render textures allow you to render any display object to a texture, which can t
 
 ## Basic Usage
 
-Create a `RenderTexture`, render a container into it each frame, and display the result in a sprite:
+Create a `RenderTexture`, render a container into it each frame, and display the result in a sprite.
+
+::: warning Keep the render source off-stage
+`renderer.render({ container, ... })` promotes `container` into its own render group as a side effect. Doing that to a container that's *also* a normal member of the visible tree (e.g. mounted under `<Container>`/`app.stage` via a template) can corrupt both the on-stage presentation and the render-texture output — PixiJS doesn't expect a render-to-texture source to also live on-stage. Build the source with plain PixiJS calls and never add it to the template/stage; only the *output* sprite needs to be a template element.
+:::
 
 ```vue
 <script setup>
-import { Container, RenderTexture, Sprite } from 'pixi.js'
-import { onMounted, ref } from 'vue'
+import { Container, Graphics, RenderTexture, Sprite } from 'pixi.js'
+import { onMounted, onUnmounted, ref } from 'vue'
 import { onTick, useApplication } from 'vue3-pixi'
 
 const app = useApplication()
-const containerRef = ref<Container>()
 const outputRef = ref<Sprite>()
 let renderTexture: RenderTexture | null = null
+let source: Container | null = null
 
 onMounted(() => {
+  // Plain PixiJS container — deliberately never added to app.stage or any
+  // mounted <Container>, so it only ever plays the "render source" role.
+  source = new Container()
+  source.addChild(new Graphics().rect(0, 0, 60, 60).fill(0xFFFFFF))
+  source.addChild(new Graphics().rect(70, 0, 60, 60).fill(0xFFFFFF))
+  source.x = 100
+  source.y = 60
+
   renderTexture = RenderTexture.create({ width: 300, height: 300 })
   if (outputRef.value) {
     outputRef.value.texture = renderTexture
   }
 })
 
+onUnmounted(() => {
+  source?.destroy({ children: true })
+  renderTexture?.destroy(true)
+})
+
 onTick(() => {
-  if (!containerRef.value || !renderTexture || !app.value)
+  if (!source || !renderTexture || !app.value)
     return
   app.value.renderer.render({
-    container: containerRef.value,
+    container: source,
     target: renderTexture,
   })
 })
 </script>
 
 <template>
-  <assets alias="bunny" entry="https://pixijs.com/assets/bunny.png">
-    <!-- Source: rendered to texture -->
-    <Container ref="containerRef" :x="100" :y="60">
-      <Sprite texture="bunny" :x="0" :y="0" />
-      <Sprite texture="bunny" :x="30" :y="30" />
-    </Container>
-    <!-- Output: displays the render texture -->
-    <Sprite ref="outputRef" :x="450" :y="60" />
-  </assets>
+  <!-- Output: displays the render texture. No on-stage copy of the source. -->
+  <Sprite ref="outputRef" :x="450" :y="60" />
 </template>
 ```
 


### PR DESCRIPTION
## Summary
Addresses #175.

`AbstractRenderer.render({ container, ... })` unconditionally calls `container.enableRenderGroup()`. That method is a one-time, idempotent promotion (`Container.enableRenderGroup()` early-returns if `this.renderGroup` is already set) — so calling it every frame on `app.stage` (which `Application`'s own internal render loop already does) is completely normal and harmless, since `app.stage` gets promoted once on the first frame and stays that way.

The problem is the *first* example in this doc: it uses a template-mounted `<Container>` — a normal on-stage tree member, parented under `app.stage`'s render group — as the manual `container` argument to `renderer.render()`. The first time that runs, the container gets detached from its parent's render group and re-promoted into its own independent render group, while remaining a live child of the stage. From then on it has two roles fighting over the same render-group/texture-cache state: PixiJS's normal per-frame stage draw, and our manual per-frame `render({ container, target })` call. The reporter saw this surface as corrupted on-stage rendering (solid black / flicker) and sometimes `GL_INVALID_OPERATION: glDrawElements: Feedback loop formed between Framebuffer and active Texture`.

This fix rebuilds the Basic Usage example so the render source is a plain PixiJS `Container` built with imperative calls and **never added to `app.stage` or any mounted `<Container>`** — matching PixiJS's own official render-texture examples, and the reporter's own suggested resolution. Added a warning callout explaining why. Left the Double-Buffering example as-is since it renders `app.value.stage` itself (already permanently a render group from Application's own per-frame render call), which isn't the dual-role case described.

## Test plan
This is a docs-only change; there's no vue3-pixi code path to unit test, and the underlying corruption is GPU-driver-state behavior. To validate as much as I could:
- [x] Traced PixiJS 8.14.3's `enableRenderGroup()`/`AbstractRenderer.render()` source to confirm the exact mechanism described above.
- [x] Built a standalone repro app (real Chromium + WebGL via Playwright, not jsdom) mounting both the old dual-role-container pattern and the new detached-container pattern side by side, including repeated `<Application>` destroy/recreate cycles. Confirmed the new pattern renders correctly and produces output pixel-identical to the old pattern under normal conditions.
- [ ] Could **not** force the reported GL corruption itself under software rendering (SwiftShader) in this sandbox — consistent with it being real-GPU/driver-dependent undefined behavior, which the reporter themselves weren't certain was deterministically reproducible either. Happy to test against a real GPU if that's available in CI, or if a maintainer can confirm/deny on hardware.